### PR TITLE
Added in Previous Btn Functionality to Results Pages

### DIFF
--- a/public/javascripts/genusResults.js
+++ b/public/javascripts/genusResults.js
@@ -7,8 +7,21 @@ nextGenusBtn.addEventListener('click', event => {
     let searchStr = destruct[0].split('=');
     let pageNum = nextGenusBtn.value;
 
-    if (pageNum !== 'reset') {
-        pageNum++;
+    pageNum++;
+    window.location.href = 'genusResults?nextGenusPage=' + searchStr[1] + '&page=' + pageNum;
+});
+
+/* Previous Button Genus Results */
+const prevGenusBtn = document.getElementById("prevGenusBtn");
+
+prevGenusBtn.addEventListener('click', event => {
+    let query = window.location.search.substring(1).split('?');
+    let destruct = query[0].split('&');
+    let searchStr = destruct[0].split('=');
+    let pageNum = prevGenusBtn.value;
+
+    if (pageNum != 2) {
+        pageNum--;
         window.location.href = 'genusResults?nextGenusPage=' + searchStr[1] + '&page=' + pageNum;
     } else {
         window.location.href = 'genusResults?genus=' + searchStr[1];

--- a/public/javascripts/searchResults.js
+++ b/public/javascripts/searchResults.js
@@ -10,8 +10,21 @@ nextSearchBtn.addEventListener('click', event => {
     console.log(pageNum);
     console.log(searchStr);
 
-    if (pageNum !== 'reset') {
-        pageNum++;
+    pageNum++;
+    window.location.href = 'searchResults?nextSearchPage=' + searchStr[1] + '&page=' + pageNum;
+});
+
+/* Previous Button Genus Results */
+const prevSearchBtn = document.getElementById("prevSearchBtn");
+
+prevSearchBtn.addEventListener('click', event => {
+    let query = window.location.search.substring(1).split('?');
+    let destruct = query[0].split('&');
+    let searchStr = destruct[0].split('=');
+    let pageNum = prevSearchBtn.value;
+
+    if (pageNum != 2) {
+        pageNum--;
         window.location.href = 'searchResults?nextSearchPage=' + searchStr[1] + '&page=' + pageNum;
     } else {
         window.location.href = 'searchResults?search=' + searchStr[1];

--- a/routes/routePaths.js
+++ b/routes/routePaths.js
@@ -25,6 +25,18 @@ router.get('/', function (req, res) {
   res.end();
 });
 
+/* GET Reference Page */
+router.get('/reference', function (req, res) {
+  res.render('referencePage');
+  res.end();
+});
+
+/* GET About Page */
+router.get('/about', function (req, res) {
+  res.render('about');
+  res.end();
+});
+
 /* GET SearchResults Page */
 /* Handles SearchBar Results */
 router.get('/searchResults', async (req, res) => {
@@ -40,8 +52,10 @@ router.get('/searchResults', async (req, res) => {
 
     res.render('searchResults', {
       results: searchObj.data.data,
-      count: 1
+      count: 1,
+      lastPg: lastPage[1]
     });
+
   } else if (determine[0] == 'nextSearchPage') { //Api returns 20 results at a time, this handles getting thet next set of results
     const queryObject = url.parse(req.url, true).query;
     let searchStr = Object.values(queryObject);
@@ -54,36 +68,20 @@ router.get('/searchResults', async (req, res) => {
     let destruct2 = destruct1[1].split('&');
     let lastPage = destruct2[0].split('=');
 
-    if (searchStr[1] <= lastPage[1]) {
-      let nextResults = await axios.get(urlAPI + '/plants/search?token=' + token + '&q=' + searchStr[0] + '&page=' + searchStr[1])
-        //.then(resp => console.log(resp.data.data))
-        .catch(err => console.error(err));
+    let nextResults = await axios.get(urlAPI + '/plants/search?token=' + token + '&q=' + searchStr[0] + '&page=' + searchStr[1])
+      //.then(resp => console.log(resp.data.data))
+      .catch(err => console.error(err));
 
-      res.render('searchResults', {
-        results: nextResults.data.data,
-        count: searchStr[1]
-      });
+    res.render('searchResults', {
+      results: nextResults.data.data,
+      count: searchStr[1],
+      lastPg: lastPage[1]
+    });
 
-    } else {
-      res.render('searchResults', {
-        results: false,
-        count: 1
-      });
-    }
   } else {
     res.render('error');
   }
 })
-
-router.get('/reference', function (req, res) {
-  res.render('referencePage');
-  res.end();
-});
-
-router.get('/about', function (req, res) {
-  res.render('about');
-  res.end();
-});
 
 /* GET GenusResults Page */
 /* Handles Genus Category Results */
@@ -97,10 +95,12 @@ router.get('/genusResults', async (req, res) => {
     let genusObj = await axios.get(urlAPI + 'genus/' + searchStr[0] + '/plants?token=' + token + '&genus=' + searchStr[0])
       //.then(resp => console.log(resp.data.data))
       .catch(err => console.error(err));
+    let lastPage = genusObj.data.links.last.slice(-1);
 
     res.render('genusResults', {
       results: genusObj.data.data,
-      count: 1
+      count: 1,
+      lastPg: lastPage
     });
 
   } else if (determine[0] == 'nextGenusPage') { //Api returns 20 results at a time, this handles getting thet next set of results
@@ -110,22 +110,18 @@ router.get('/genusResults', async (req, res) => {
     let check = await axios.get(urlAPI + 'genus/' + searchStr[0] + '/plants?token=' + token + '&genus=' + searchStr[0])
       //.then(resp => console.log(resp.data.data))
       .catch(err => console.error(err));
+    let lastPage = check.data.links.last.slice(-1);
 
-    if (searchStr[1] <= check.data.links.last.slice(-1)) {
-      let nextResults = await axios.get(urlAPI + '/plants?token=' + token + '&genus=' + searchStr[0] + '&page=' + searchStr[1])
-        //.then(resp => console.log(resp.data.data))
-        .catch(err => console.error(err));
+    let nextResults = await axios.get(urlAPI + '/plants?token=' + token + '&genus=' + searchStr[0] + '&page=' + searchStr[1])
+      //.then(resp => console.log(resp.data.data))
+      .catch(err => console.error(err));
 
-      res.render('genusResults', {
-        results: nextResults.data.data,
-        count: searchStr[1]
-      });
-    } else {
-      res.render('genusResults', {
-        results: false,
-        count: 1
-      });
-    }
+    res.render('genusResults', {
+      results: nextResults.data.data,
+      count: searchStr[1],
+      lastPg: lastPage
+    });
+
   } else {
     res.render('error');
   }

--- a/views/genusResults.ejs
+++ b/views/genusResults.ejs
@@ -18,7 +18,6 @@
 
     <section class="result_list">
 
-      <% if (results) { %>
       <table class="table text-light" id="table" class="text-light" data-toggle="table">
         <thead>
           <tr>
@@ -46,18 +45,17 @@
         </tbody>
 
       </table>
-      <% } else { %>
-      <section class="card">
-        <div class="card-body">
-          <h1 class="card-title">No More Results</h1>
-        </div>
-      </section>
+
+
+      <% if (count > 1) { %>
+      <button id="prevGenusBtn" class="btn btn-primary" role="button" value="<%= count %>">Previous</button>
       <% } %>
 
-      <% if (results) { %>
+      <% if (count < lastPg) { %>
       <button id="nextGenusBtn" class="btn btn-primary" role="button" value="<%= count %>">Next</button>
       <% } else { %>
-      <button id="nextGenusBtn" class="btn btn-primary" role="button" value="reset">First Page</button>
+      <!-- Ignore styling this or changing, created solely so the JS still works (it not visible and disabled)-->
+      <button id="nextGenusBtn" class="btn btn-primary d-none" disabled role="button" value="<%= count %>">Next</button>
       <% } %>
 
     </section>

--- a/views/searchResults.ejs
+++ b/views/searchResults.ejs
@@ -18,7 +18,6 @@
 
         <section class="result_list">
 
-            <% if (results) { %>
             <table class="table text-light" id="table" class="text-light" data-toggle="table">
                 <thead>
                     <tr>
@@ -46,22 +45,18 @@
                 </tbody>
 
             </table>
-            <% } else { %>
-            <section class="card">
-                <div class="card-body">
-                    <h1 class="card-title">No More Results</h1>
-                </div>
-            </section>
+
+            <% if (count > 1) { %>
+            <button id="prevSearchBtn" class="btn btn-primary" role="button" value="<%= count %>">Previous</button>
             <% } %>
 
-
-            <% if (results) { %>
+            <% if (count < lastPg) { %>
             <button id="nextSearchBtn" class="btn btn-primary" role="button" value="<%= count %>">Next</button>
             <% } else { %>
-            <button id="nextSearchBtn" class="btn btn-primary" role="button" value="reset">First Page</button>
+            <!-- Ignore styling this or changing, created solely so the JS still works (it not visible and disabled)-->
+            <button id="nextSearchBtn" class="btn btn-primary d-none" disabled role="button"
+                value="<%= count %>">Next</button>
             <% } %>
-
-
 
         </section>
 


### PR DESCRIPTION
-included a previous button that will go back to the previous page of results
-reworked the JS and routePaths to handle that functionailty
-no longer a werid (No more results) page when you go past the last page
-removed old EJS logic on the pages and reworked it to be simpler & work with the previous buttons
-No previous button on first page, no next button on the last page
-Due to logic i had to create the next button when your on the last page so the JS still works but it's hidden and disabled so you can't accidently click on where the button might be and activate it